### PR TITLE
Added Tokyo-Night palette

### DIFF
--- a/palettes/tokyo-night.json
+++ b/palettes/tokyo-night.json
@@ -1,0 +1,23 @@
+{
+    "type": "palette",
+    "name": "Tokyo-Night",
+    "desc": "A clean theme that celebrates the lights of Downtown Tokyo at night.",
+    "smooth": true,
+    "colors": [
+        "#32344a",
+        "#444b6a",
+        "#9699a8",
+        "#acb0d0",
+        "#9ece6a",
+        "#7aa2f7",
+        "#7aa2f7",
+        "#f7768e",
+        "#ff7a93",
+        "#e0af68",
+        "#ff9e64",
+        "#449dab",
+	"#0db9d7",
+	"#ad8ee6",
+	"#bb9af7"
+    ]
+}


### PR DESCRIPTION
Added the Tokyo-Night colour palette ported from https://github.com/eendroroy/alacritty-theme which is based off https://github.com/folke/tokyonight.nvim.