### PR TITLE
Replaced dependency on colormath with basic_colormath

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.venv
+build
 resources/demo.mp4
 test/theme/
 *.egg-info/

--- a/color_manager/utils.py
+++ b/color_manager/utils.py
@@ -186,7 +186,7 @@ def generate_palette_dict(colors:List[str]) -> Dict[str,Lab]:
 
     for color in colors:
         r, g, b = hex_to_rgb(color)
-        palette_dict[color] = rgbs_to_lab(RGB(r,g,b), Lab)
+        palette_dict[color] = rgbs_to_lab(Annotated[RGB,(r,g,b)], Lab)
 
     return palette_dict
 
@@ -232,7 +232,7 @@ def closest_match(color:str, palette:Dict[str,Lab]) -> str:
 
         if lab_color is None:
             r, g, b = hex_to_rgb(color)
-            lab_color = rgbs_to_lab(RGB(r,g,b), Lab)
+            lab_color = rgbs_to_lab(Annotated[RGB,(r,g,b)], Lab)
             hex_to_lab_dict[color] = lab_color
 
         distance = get_delta_e_lab(lab_color, palette[entry])

--- a/color_manager/utils.py
+++ b/color_manager/utils.py
@@ -1,11 +1,11 @@
 # Desc: A program for recoloring icon packs, themes and wallpapers. For NovaOS.
 # Auth: Nicklas Vraa
 
-from typing import List, Set, Tuple, Dict, Optional
+from typing import Annotated, List, Set, Tuple, Dict, Optional
 from tqdm import tqdm
-from colormath.color_objects import sRGBColor, LabColor
-from colormath.color_conversions import convert_color
-from colormath.color_diff import delta_e_cie2000
+from basic_colormath.type_hints import RGB, Lab
+from basic_colormath.vec_distance import rgbs_to_lab
+from basic_colormath.distance import get_delta_e_lab
 from PIL import Image, ImageDraw
 import os, re, shutil, json, subprocess
 
@@ -180,13 +180,13 @@ def expand_all_hex(text:str) -> str:
 
 # Color comparision ------------------------------------------------------------
 
-def generate_palette_dict(colors:List[str]) -> Dict[str,LabColor]:
+def generate_palette_dict(colors:List[str]) -> Dict[str,Lab]:
     """ Returns a dictionary mapping hexadecimal colors to lab colors. """
     palette_dict = {}
 
     for color in colors:
         r, g, b = hex_to_rgb(color)
-        palette_dict[color] = convert_color(sRGBColor(r,g,b), LabColor)
+        palette_dict[color] = rgbs_to_lab(RGB(r,g,b), Lab)
 
     return palette_dict
 
@@ -219,7 +219,7 @@ def get_file_colors(text:str) -> Set[str]:
 
     return colors
 
-def closest_match(color:str, palette:Dict[str,LabColor]) -> str:
+def closest_match(color:str, palette:Dict[str,Lab]) -> str:
     """ Compare the similarity of colors in the CIELAB colorspace. Return the closest match, i.e. the palette entry with the smallest euclidian distance to the given color. """
 
     closest_color = None
@@ -232,10 +232,10 @@ def closest_match(color:str, palette:Dict[str,LabColor]) -> str:
 
         if lab_color is None:
             r, g, b = hex_to_rgb(color)
-            lab_color = convert_color(sRGBColor(r,g,b), LabColor)
+            lab_color = rgbs_to_lab(RGB(r,g,b), Lab)
             hex_to_lab_dict[color] = lab_color
 
-        distance = delta_e_cie2000(lab_color, palette[entry])
+        distance = get_delta_e_lab(lab_color, palette[entry])
 
         if distance < min_distance:
             min_distance = distance
@@ -347,7 +347,7 @@ def apply_monotones_to_vec(text:str, colors:Set[str], hsl:Tuple[float,float,floa
 
     return text
 
-def apply_palette_to_vec(text:str, colors:Set[str], new_colors:Dict[str,LabColor]) -> str:
+def apply_palette_to_vec(text:str, colors:Set[str], new_colors:Dict[str,Lab]) -> str:
     """ Replace hexadecimal color codes in a given svg/xml/css string with their closest matches within the given color palette. """
 
     for color in colors:
@@ -398,7 +398,7 @@ def apply_monotones_to_img(img:Image, hsl:Tuple[float,float,float]) -> Image:
 
     return img
 
-def apply_palette_to_img(img:Image, new_colors:Dict[str,LabColor], smooth:bool) -> Image:
+def apply_palette_to_img(img:Image, new_colors:Dict[str,Lab], smooth:bool) -> Image:
     """ Replace colors in a given image with the closest match within a given color palette. """
 
     if smooth: img = img.convert("P", palette=Image.ADAPTIVE, colors=256)
@@ -616,8 +616,8 @@ def add_backdrop(src_path:str, dest_path:str, name:str, color:str="#000000", pad
 
 # A dynamic dictionary to avoid multiple color conversions.
 hex_to_lab_dict = {
-    "#ffffff": LabColor(9341.568974319263, -0.037058350415009045, -0.6906417562959177), # White.
-    "#000000": LabColor(0,0,0) # Black.
+    "#ffffff": Annotated[Lab,(9341.568974319263, -0.037058350415009045, -0.6906417562959177)], # White.
+    "#000000": Annotated[Lab,(0,0,0)] # Black.
 }
 
 # A static dictionary of named colors from the css standard.

--- a/color_manager/utils.py
+++ b/color_manager/utils.py
@@ -3,11 +3,22 @@
 
 from typing import Annotated, List, Set, Tuple, Dict, Optional
 from tqdm import tqdm
-from basic_colormath.type_hints import RGB, Lab
-from basic_colormath.vec_distance import rgbs_to_lab
-from basic_colormath.distance import get_delta_e_lab
+# from basic_colormath.type_hints import RGB, Lab
+from basic_colormath.distance import rgb_to_lab, get_delta_e_lab
 from PIL import Image, ImageDraw
 import os, re, shutil, json, subprocess
+
+
+# Using custom type hints as the default ones in basic_colormath.type_hits arent compatible past python 3.8
+
+RGB = Annotated[tuple[float, float, float], ([0, 255], [0, 255], [0, 255])]
+Lab = Annotated[tuple[float, float, float], ([0, 100], [-128, 127], [-128, 127])]
+
+def LabColor(L:float, a:float, b:float) -> Lab:
+    return L, a, b
+
+def sRGBColor(r:float, g:float, b:float) -> RGB:
+    return r,g,b
 
 # Basic utility ----------------------------------------------------------------
 
@@ -186,7 +197,7 @@ def generate_palette_dict(colors:List[str]) -> Dict[str,Lab]:
 
     for color in colors:
         r, g, b = hex_to_rgb(color)
-        palette_dict[color] = rgbs_to_lab(Annotated[RGB,(r,g,b)], Lab)
+        palette_dict[color] = rgb_to_lab(sRGBColor(r,g,b))
 
     return palette_dict
 
@@ -232,7 +243,7 @@ def closest_match(color:str, palette:Dict[str,Lab]) -> str:
 
         if lab_color is None:
             r, g, b = hex_to_rgb(color)
-            lab_color = rgbs_to_lab(Annotated[RGB,(r,g,b)], Lab)
+            lab_color = rgb_to_lab(sRGBColor(r,g,b))
             hex_to_lab_dict[color] = lab_color
 
         distance = get_delta_e_lab(lab_color, palette[entry])
@@ -616,8 +627,8 @@ def add_backdrop(src_path:str, dest_path:str, name:str, color:str="#000000", pad
 
 # A dynamic dictionary to avoid multiple color conversions.
 hex_to_lab_dict = {
-    "#ffffff": Annotated[Lab,(9341.568974319263, -0.037058350415009045, -0.6906417562959177)], # White.
-    "#000000": Annotated[Lab,(0,0,0)] # Black.
+    "#ffffff": LabColor(9341.568974319263, -0.037058350415009045, -0.6906417562959177), # White.
+    "#000000": LabColor(0,0,0) # Black.
 }
 
 # A static dictionary of named colors from the css standard.

--- a/readme.md
+++ b/readme.md
@@ -86,7 +86,7 @@ rounding = 0.5 # Optional - Between 0 and 1, i.e. rectangle and ellipse.
 utils.add_backdrop(src, dest, name, color, padding, rounding)
 ```
 
-Or launch the GUI by running `python3 color_manager/gui.py` in a terminal from the project's root directory. The GUI will adopt your active theme. Dependencies: `colormath`, `tqdm` and `pillow`. For the GUI, `pygobject` (GTK bindings) must also be installed.
+Or launch the GUI by running `python3 color_manager/gui.py` in a terminal from the project's root directory. The GUI will adopt your active theme. Dependencies: `basic_colormath`, `tqdm` and `pillow`. For the GUI, `pygobject` (GTK bindings) must also be installed.
 
 **Defining a palette or mapping** is either done as a dict-object or as an external json-file, e.g.:
 ```python

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     },
     exclude=["tests", "packs"],
     install_requires=[
-        "colormath",
+        "basic_colormath",
         "tqdm",
         "pillow"
     ],


### PR DESCRIPTION
I replaced colormath with the basic_colormath package, which fixes the dependency on numpy.asscalar.

This is largely a _wip_ as I haven't had the chance to test it on more iconsets and compare the results with the colormath version, but it seems to work and is a fair bit faster now.

