### PR TITLE
fix: rgb color support for .svg files

### DIFF
--- a/color_manager/utils.py
+++ b/color_manager/utils.py
@@ -156,11 +156,21 @@ def expand_css_rgba(match) -> str:
         int(match.group(3)), float(match.group(4))
     ))
 
+def expand_css_rgb(match) -> str:
+    """ Used by the css_to_hex function. """
+    return rgb_to_hex((
+        int(match.group(1)), int(match.group(2)),
+        int(match.group(3)))
+    )
+
 def css_to_hex(text:str) -> str:
     """ Returns the given string with css rgba functions and named colors substituted for their corresponding hexadecimal codes. """
 
     text = re.sub(r"rgba\((\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*([\d.]+)\)",
                   expand_css_rgba, text)
+
+    text = re.sub(r"rgb\((\d+)\s*,\s*(\d+)\s*,\s*(\d+)\)",
+                  expand_css_rgb, text)
 
     for key in name_to_hex_dict:
         text = re.sub(key + r"\b", name_to_hex_dict[key], text)

--- a/color_manager/utils.py
+++ b/color_manager/utils.py
@@ -479,6 +479,8 @@ def recolor(src_path:str, dest_path:str, name:str, replacement) -> None:
     for path in tqdm(paths, desc="svg", disable=is_empty(paths)):
         with open(path, 'r') as file: x = file.read()
 
+        # .svg files use similar color formats to css
+        x = css_to_hex(x)
         x = expand_all_hex(x)
         colors = get_file_colors(x)
 


### PR DESCRIPTION
Currently, only hex colors in .svg files are recolored. This adds support for rgb and rgba colors as well. It reuses `expand_css_rgb` and as a side effect, also adds support for rgb colors for css stylesheets rather than just rgba colors.
 
To my understanding, this should resolve #8.

P.S. I just wanted to say that this is a fantastic project and I cannot tell you how long I have wanted something that recolors entire icon themes like this!